### PR TITLE
implement `sanitize_html`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "dom_query",
  "html5ever",
  "regex",
+ "tendril",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [".*", "test-pages", "examples"]
 [dependencies]
 dom_query = {version = "0.18.0"}
 html5ever = {version = "0.31.0"}
+tendril = {version = "0.4.3"}
 
 [dev-dependencies]
 regex = {version = "1.11.1"}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Both policies may remove given elements and their descendants from the DOM. This
 <summary><b>A Basic PermissivePolicy</b></summary>
 
 ```rust
-use dom_sanitizer::{PermissivePolicy, RestrictivePolicy};
+use dom_sanitizer::PermissivePolicy;
 use dom_query::Document;
 
 // `PermissivePolicy<'a>`, as well as `AllowAllPolicy`, is an alias for `Policy<'a, Permissive>`
@@ -85,13 +85,13 @@ assert_eq!(doc.select("a[href]").length(), 0);
 <summary><b>A Basic RestrictivePolicy</b></summary>
 
 ```rust
-use dom_sanitizer::{PermissivePolicy, RestrictivePolicy};
+use dom_sanitizer::RestrictivePolicy;
 use dom_query::Document;
 
 
 // `RestrictivePolicy<'a>`, as well as `DenyAllPolicy`, is an alias for `Policy<'a, Restrictive>` 
 
-// Create a new permissive policy with builder
+// Create a new restrictive policy with builder
 let policy = RestrictivePolicy::builder()
     // allow only `p` and `a` elements
     .exclude_elements(&["p", "a"])
@@ -174,6 +174,45 @@ let _policy = RestrictivePolicy::builder()
     .exclude_element_attrs("a", &["href"])
     .remove_elements(&["style", "script"])
     .build();
+```
+</details>
+
+
+<details>
+<summary><b>HTML Sanitizing</b></summary>
+
+```rust
+use dom_sanitizer::PermissivePolicy;
+use dom_query::Document;
+
+
+// Create a new permissive policy with builder
+let policy = PermissivePolicy::builder()
+    // remove `style` elements including their descendants (elements, text, comments)
+    .remove_elements(&["style"])
+    .build();
+
+let contents: &str = r#"
+    <!DOCTYPE html>
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <style>
+                p { border-bottom: 2px solid black; }
+            </style>
+            <div><p role="paragraph">The first paragraph contains <a href="/first" role="link">the first link</a>.</p></div>
+            <div></div>
+        </body>
+    </html>"#;
+
+assert!(contents.contains("<style>"));
+assert!(contents.contains(r#"p { border-bottom: 2px solid black; }"#));
+
+let html = policy.sanitize_html(contents);
+
+assert!(!html.contains("<style>"));
+assert!(!html.contains(r#"p { border-bottom: 2px solid black; }"#));
+
 ```
 </details>
 

--- a/src/plugin_policy/core.rs
+++ b/src/plugin_policy/core.rs
@@ -1,5 +1,6 @@
 use dom_query::{Document, NodeRef};
 use html5ever::Attribute;
+use tendril::StrTendril;
 
 use super::builder::PluginPolicyBuilder;
 use crate::{Permissive, Restrictive};
@@ -194,9 +195,16 @@ impl<T: SanitizePluginDirective> PluginPolicy<T> {
         node.normalize();
     }
 
-    /// Sanitizes the attributes of a node by applying the policy rules according to the directive type.
+    /// Sanitizes the document.
     pub fn sanitize_document(&self, document: &Document) {
         self.sanitize_node(&document.root());
+    }
+
+    /// Sanitizes the HTML content by applying the policy rules according to the directive type.
+    pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
+        let doc = Document::from(html);
+        self.sanitize_document(&doc);
+        doc.html()
     }
 }
 

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -1,4 +1,5 @@
 use dom_query::{Document, NodeRef};
+use tendril::StrTendril;
 
 use super::builder::PolicyBuilder;
 use crate::{Permissive, Restrictive};
@@ -136,7 +137,7 @@ pub struct AttributeRule<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Policy<'a, T: SanitizeDirective = Restrictive> {
+pub struct Policy<'a, T =  Restrictive> {
     /// The list of excluding rules for attributes.
     /// For [Permissive] directive: attributes to remove
     /// For [Restrictive] directive: attributes to keep
@@ -170,9 +171,15 @@ impl<T: SanitizeDirective> Policy<'_, T> {
         T::sanitize_node(self, node);
         node.normalize();
     }
-    /// Sanitizes the attributes of a node by applying the policy rules according to the directive type.
+    /// Sanitizes the document.
     pub fn sanitize_document(&self, document: &Document) {
         self.sanitize_node(&document.root());
+    }
+    /// Sanitizes the HTML content by applying the policy rules according to the directive type.
+    pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
+        let doc = Document::from(html);
+        self.sanitize_document(&doc);
+        doc.html()
     }
 }
 

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -137,7 +137,7 @@ pub struct AttributeRule<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Policy<'a, T =  Restrictive> {
+pub struct Policy<'a, T: SanitizeDirective =  Restrictive> {
     /// The list of excluding rules for attributes.
     /// For [Permissive] directive: attributes to remove
     /// For [Restrictive] directive: attributes to keep

--- a/tests/plugin_policy.rs
+++ b/tests/plugin_policy.rs
@@ -230,6 +230,10 @@ fn test_permissive_plugin_policy_exclude_attr() {
     assert!(!doc.select("style").exists());
     assert!(!doc.select("a[onanimationend]").exists());
     assert!(doc.select("a").exists());
+
+    assert!(contents.contains(r#"onanimationend="alert(1)""#));
+    let html = policy.sanitize_html(contents);
+    assert!(!html.contains(r#"onanimationend="alert(1)""#));
 }
 
 #[test]

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -137,3 +137,20 @@ fn test_restrictive_policy_remove() {
     assert!(!doc.select("style").exists());
     assert!(!doc.html().contains("border-collapse: collapse"));
 }
+
+
+#[test]
+fn test_restrictive_policy_remove_html() {
+    // Removing elements with `DenyAllPolicy` works the same way as with `AllowAllPolicy`.
+
+    let policy = AllowAllPolicy::builder().remove_elements(&["style"]).build();
+    let contents = include_str!("../test-pages/table.html");
+    assert!(contents.contains("border-collapse: collapse"));
+    assert!(contents.contains("<style>"));
+    let html = policy.sanitize_html(
+        contents,
+    );
+
+    assert!(!html.contains("<style>"));
+    assert!(!html.contains("border-collapse: collapse"));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a convenient method to sanitize raw HTML strings directly using both restrictive and plugin-based policies.
  - Enhanced documentation and examples to demonstrate HTML string sanitization and removal of specific elements like <style>.

- **Bug Fixes**
  - Corrected comments in examples and documentation to accurately reflect policy usage.

- **Tests**
  - Added and extended tests to verify string-level HTML sanitization and element removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->