### PR TITLE
add an example with the namespace exclusion

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -14,7 +14,7 @@ Both policies may remove given elements and their descendants from the DOM. This
 
 
 <details>
-<summary><b>A Basic PermissivePolicy</b></summary>
+<summary><b>A Basic `PermissivePolicy`</b></summary>
 
 ```rust
 use dom_sanitizer::PermissivePolicy;
@@ -69,7 +69,7 @@ assert_eq!(doc.select("a[href]").length(), 0);
 
 
 <details>
-<summary><b>A Basic RestrictivePolicy</b></summary>
+<summary><b>A Basic `RestrictivePolicy`</b></summary>
 
 ```rust
 use dom_sanitizer::RestrictivePolicy;
@@ -543,5 +543,84 @@ It utilizes the `atomic` feature, which is required to share `dom_query::Documen
         assert!(doc.select("table tr > td").exists());
     }
 }
+```
+</details>
+
+<details>
+<summary><b>Allowing a Namespace in a Restrictive Plugin Policy (SVG)</b></summary>
+
+When sanitizing elements such as `<svg>` or `<math>`, explicitly listing all allowed elements and attributes can be overly verbose.
+Instead, you can create a `NodeChecker` that allows all elements within a specific namespace, or an `AttrChecker` that allows all attributes for certain elements.
+
+```rust
+use dom_query::{Document, NodeRef};
+use dom_sanitizer::plugin_policy::{preset, AttrChecker, PluginPolicy};
+use dom_sanitizer::{Permissive, Restrictive};
+use html5ever::{ns, LocalName};
+
+// HTML with a **malicious** SVG
+let content: &str = r#"
+<!DOCTYPE html>
+<html>
+    <head><title>Test</title></head>
+    <body>
+        <svg oncontentvisibilityautostatechange=alert(1) style=display:block;content-visibility:auto
+            viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" role="img">
+            <title>A gradient</title>
+            <linearGradient id="gradient">
+                <stop class="begin" offset="0%" stop-color="red" />
+                <stop class="end" offset="100%" stop-color="black" />
+            </linearGradient>
+            <rect x="0" y="0" width="100" height="100" style="fill:url(#gradient)" />
+            <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
+        </svg>
+        <p>Some text</p>
+        <div>Some other text</div>
+    </body>
+</html>"#;
+
+    // Define a custom attribute checker that allows all attributes 
+    // for elements in the SVG namespace, except those whose names start with "on".
+    struct SvgSafeAttrs;
+
+    impl AttrChecker for SvgSafeAttrs {
+        fn is_match_attr(&self, node: &NodeRef, attr: &html5ever::Attribute) -> bool {
+            if !node
+                .qual_name_ref()
+                .map_or(false, |name| name.ns == ns!(svg))
+            {
+                return false;
+            }
+            !attr.name.local.to_ascii_lowercase().starts_with("on")
+        }
+    }
+    // Create a policy that strips all elements and attributes,
+    // except those explicitly excluded.
+    let policy: PluginPolicy<Restrictive> = PluginPolicy::builder()
+        // Allow all elements from the SVG namespace.
+        .exclude(preset::NamespaceMatcher::new("http://www.w3.org/2000/svg"))
+        // Also allow <div> elements.
+        .exclude(preset::LocalNameMatcher::new("div"))
+        // Allow all attributes on elements in the SVG namespace, except those starting with `on`.
+        .exclude_attr(SvgSafeAttrs)
+        .build();
+
+    let doc = Document::from(content);
+
+    policy.sanitize_document(&doc);
+    
+    // The SVG no longer has the `oncontentvisibilityautostatechange` attribute.
+    assert!(!doc
+        .select("svg[oncontentvisibilityautostatechange]")
+        .exists());
+    // The SVG still has the `style` attribute.
+    assert!(doc.select("svg[style]").exists());
+    // Other elements in the SVG namespace still have their attributes.
+    assert!(doc.select("circle[r][style]").exists());
+    assert!(doc.select("rect[width][height][style]").exists());
+    // The <div> element was preserved.
+    assert!(doc.select("div").exists());
+    // The <p> element was removed.
+    assert!(!doc.select("p").exists());
 ```
 </details>

--- a/Examples.md
+++ b/Examples.md
@@ -555,11 +555,11 @@ Instead, you can create a `NodeChecker` that allows all elements within a specif
 ```rust
 use dom_query::{Document, NodeRef};
 use dom_sanitizer::plugin_policy::{preset, AttrChecker, PluginPolicy};
-use dom_sanitizer::{Permissive, Restrictive};
+use dom_sanitizer::Restrictive;
 use html5ever::{ns, LocalName};
 
 // HTML with a **malicious** SVG
-let content: &str = r#"
+let contents: &str = r#"
 <!DOCTYPE html>
 <html>
     <head><title>Test</title></head>
@@ -598,14 +598,14 @@ let content: &str = r#"
     // except those explicitly excluded.
     let policy: PluginPolicy<Restrictive> = PluginPolicy::builder()
         // Allow all elements from the SVG namespace.
-        .exclude(preset::NamespaceMatcher::new("http://www.w3.org/2000/svg"))
+        .exclude(preset::NamespaceMatcher(ns!(svg)))
         // Also allow <div> elements.
         .exclude(preset::LocalNameMatcher::new("div"))
         // Allow all attributes on elements in the SVG namespace, except those starting with `on`.
         .exclude_attr(SvgSafeAttrs)
         .build();
 
-    let doc = Document::from(content);
+    let doc = Document::from(contents);
 
     policy.sanitize_document(&doc);
     

--- a/README.md
+++ b/README.md
@@ -568,11 +568,11 @@ Instead, you can create a `NodeChecker` that allows all elements within a specif
 ```rust
 use dom_query::{Document, NodeRef};
 use dom_sanitizer::plugin_policy::{preset, AttrChecker, PluginPolicy};
-use dom_sanitizer::{Permissive, Restrictive};
+use dom_sanitizer::Restrictive;
 use html5ever::{ns, LocalName};
 
 // HTML with a **malicious** SVG
-let content: &str = r#"
+let contents: &str = r#"
 <!DOCTYPE html>
 <html>
     <head><title>Test</title></head>
@@ -611,14 +611,14 @@ let content: &str = r#"
     // except those explicitly excluded.
     let policy: PluginPolicy<Restrictive> = PluginPolicy::builder()
         // Allow all elements from the SVG namespace.
-        .exclude(preset::NamespaceMatcher::new("http://www.w3.org/2000/svg"))
+        .exclude(preset::NamespaceMatcher(ns!(svg)))
         // Also allow <div> elements.
         .exclude(preset::LocalNameMatcher::new("div"))
         // Allow all attributes on elements in the SVG namespace, except those starting with `on`.
         .exclude_attr(SvgSafeAttrs)
         .build();
 
-    let doc = Document::from(content);
+    let doc = Document::from(contents);
 
     policy.sanitize_document(&doc);
     

--- a/README.md
+++ b/README.md
@@ -559,6 +559,84 @@ It utilizes the `atomic` feature, which is required to share `dom_query::Documen
 ```
 </details>
 
+<details>
+<summary><b>Allowing a Namespace in a Restrictive Plugin Policy (SVG)</b></summary>
+
+When sanitizing elements such as `<svg>` or `<math>`, explicitly listing all allowed elements and attributes can be overly verbose.
+Instead, you can create a `NodeChecker` that allows all elements within a specific namespace, or an `AttrChecker` that allows all attributes for certain elements.
+
+```rust
+use dom_query::{Document, NodeRef};
+use dom_sanitizer::plugin_policy::{preset, AttrChecker, PluginPolicy};
+use dom_sanitizer::{Permissive, Restrictive};
+use html5ever::{ns, LocalName};
+
+// HTML with a **malicious** SVG
+let content: &str = r#"
+<!DOCTYPE html>
+<html>
+    <head><title>Test</title></head>
+    <body>
+        <svg oncontentvisibilityautostatechange=alert(1) style=display:block;content-visibility:auto
+            viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" role="img">
+            <title>A gradient</title>
+            <linearGradient id="gradient">
+                <stop class="begin" offset="0%" stop-color="red" />
+                <stop class="end" offset="100%" stop-color="black" />
+            </linearGradient>
+            <rect x="0" y="0" width="100" height="100" style="fill:url(#gradient)" />
+            <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
+        </svg>
+        <p>Some text</p>
+        <div>Some other text</div>
+    </body>
+</html>"#;
+
+    // Define a custom attribute checker that allows all attributes 
+    // for elements in the SVG namespace, except those whose names start with "on".
+    struct SvgSafeAttrs;
+
+    impl AttrChecker for SvgSafeAttrs {
+        fn is_match_attr(&self, node: &NodeRef, attr: &html5ever::Attribute) -> bool {
+            if !node
+                .qual_name_ref()
+                .map_or(false, |name| name.ns == ns!(svg))
+            {
+                return false;
+            }
+            !attr.name.local.to_ascii_lowercase().starts_with("on")
+        }
+    }
+    // Create a policy that strips all elements and attributes,
+    // except those explicitly excluded.
+    let policy: PluginPolicy<Restrictive> = PluginPolicy::builder()
+        // Allow all elements from the SVG namespace.
+        .exclude(preset::NamespaceMatcher::new("http://www.w3.org/2000/svg"))
+        // Also allow <div> elements.
+        .exclude(preset::LocalNameMatcher::new("div"))
+        // Allow all attributes on elements in the SVG namespace, except those starting with `on`.
+        .exclude_attr(SvgSafeAttrs)
+        .build();
+
+    let doc = Document::from(content);
+
+    policy.sanitize_document(&doc);
+    
+    // The SVG no longer has the `oncontentvisibilityautostatechange` attribute.
+    assert!(!doc
+        .select("svg[oncontentvisibilityautostatechange]")
+        .exists());
+    // The SVG still has the `style` attribute.
+    assert!(doc.select("svg[style]").exists());
+    // Other elements in the SVG namespace still have their attributes.
+    assert!(doc.select("circle[r][style]").exists());
+    assert!(doc.select("rect[width][height][style]").exists());
+    // The <div> element was preserved.
+    assert!(doc.select("div").exists());
+    // The <p> element was removed.
+    assert!(!doc.select("p").exists());
+```
+</details>
 
 ## Crate Features
 

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -25,11 +25,11 @@ impl SanitizeDirective for Permissive {
             }
 
             next_node = next_child_or_sibling(&child, false);
-
             if !policy.should_exclude(&child) {
                 Self::sanitize_node_attrs(policy, &child);
                 continue;
             }
+
             if let Some(first_inline) = child.first_child() {
                 child.insert_siblings_before(&first_inline);
             };
@@ -53,7 +53,7 @@ pub struct Restrictive;
 
 impl Restrictive {
     /// Checks if the node should be skipped during sanitization and never be removed.
-    pub(crate) fn should_skip(node: &NodeRef) -> bool {
+    fn should_skip(node: &NodeRef) -> bool {
         node.qual_name_ref().map_or(false, |qual_name| {
             matches!(
                 qual_name.local,

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -29,6 +29,6 @@ pub static SVG_CONTENTS: &str = r#"
             <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
         </svg>
         <p>Some text</p>
-        <div>Some other text</div>
+        <div class="text">Some other text</div>
     </body>
 </html>"#;

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub static PARAGRAPH_CONTENTS: &str = r#"
 <!DOCTYPE html>
 <html>
@@ -8,5 +10,25 @@ pub static PARAGRAPH_CONTENTS: &str = r#"
         <div><p role="paragraph">The third paragraph contains <a href="/third" role="link">the third link</a>.</p></div>
         <div><p id="highlight" role="paragraph"><mark>highlighted text</mark>, <b>bold text</b></p></div>
         <div></div>
+    </body>
+</html>"#;
+
+pub static SVG_CONTENTS: &str = r#"
+<!DOCTYPE html>
+<html>
+    <head><title>Test</title></head>
+    <body>
+        <svg oncontentvisibilityautostatechange=alert(1) style=display:block;content-visibility:auto
+            viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice" role="img">
+            <title>A gradient</title>
+            <linearGradient id="gradient">
+                <stop class="begin" offset="0%" stop-color="red" />
+                <stop class="end" offset="100%" stop-color="black" />
+            </linearGradient>
+            <rect x="0" y="0" width="100" height="100" style="fill:url(#gradient)" />
+            <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
+        </svg>
+        <p>Some text</p>
+        <div>Some other text</div>
     </body>
 </html>"#;

--- a/tests/plugin_policy.rs
+++ b/tests/plugin_policy.rs
@@ -327,6 +327,7 @@ fn test_permissive_policy_svg_class() {
 
     assert!(!doc.select("svg *[style]").exists());
     assert!(!doc.select("svg *[class]").exists());
+    assert!(doc.select("div[class]").exists());
 }
 
 #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new example demonstrating how to allow a namespace in a restrictive plugin policy, with a focus on SVG content and attribute filtering.
  - Improved formatting in existing documentation examples.
  - Updated README with a detailed SVG namespace sanitization example.

- **New Features**
  - Introduced namespace-aware matchers for nodes and attributes, enabling more precise control over allowed content based on XML namespaces.

- **Tests**
  - Added tests covering SVG sanitization scenarios, including namespace and attribute-based filtering in both permissive and restrictive plugin policies.

- **Style**
  - Made minor whitespace adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->