### PR TITLE
src/: revise visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod plugin_policy;
 pub mod policy;
 pub mod traits;
 
+#[doc(inline)]
 pub use directives::{Permissive, Restrictive};
 pub use policy::*;

--- a/src/plugin_policy.rs
+++ b/src/plugin_policy.rs
@@ -2,6 +2,9 @@ pub mod builder;
 pub mod core;
 pub mod preset;
 
+#[doc(inline)]
 pub use builder::PluginPolicyBuilder;
+#[doc(inline)]
 pub use core::{AttrChecker, NodeChecker, PluginPolicy};
+#[doc(inline)]
 pub use core::{PermissivePluginPolicy, RestrictivePluginPolicy};

--- a/src/plugin_policy/core.rs
+++ b/src/plugin_policy/core.rs
@@ -29,10 +29,10 @@ pub trait AttrChecker: Send + Sync {
 /// A plugin based policy for sanitizing HTML documents.
 #[derive(Clone)]
 pub struct PluginPolicy<T: SanitizeDirective = Restrictive> {
-    pub exclude_checkers: Arc<[Box<dyn NodeChecker>]>,
-    pub remove_checkers: Arc<[Box<dyn NodeChecker>]>,
-    pub attr_exclude_checkers: Arc<[Box<dyn AttrChecker>]>,
-    pub(crate) _directive: std::marker::PhantomData<T>,
+    pub (crate) exclude_checkers: Arc<[Box<dyn NodeChecker>]>,
+    pub (crate) remove_checkers: Arc<[Box<dyn NodeChecker>]>,
+    pub (crate) attr_exclude_checkers: Arc<[Box<dyn AttrChecker>]>,
+    pub (crate) _directive: std::marker::PhantomData<T>,
 }
 
 impl<T: SanitizeDirective> fmt::Debug for PluginPolicy<T> {

--- a/src/plugin_policy/core.rs
+++ b/src/plugin_policy/core.rs
@@ -29,10 +29,10 @@ pub trait AttrChecker: Send + Sync {
 /// A plugin based policy for sanitizing HTML documents.
 #[derive(Clone)]
 pub struct PluginPolicy<T: SanitizeDirective = Restrictive> {
-    pub (crate) exclude_checkers: Arc<[Box<dyn NodeChecker>]>,
-    pub (crate) remove_checkers: Arc<[Box<dyn NodeChecker>]>,
-    pub (crate) attr_exclude_checkers: Arc<[Box<dyn AttrChecker>]>,
-    pub (crate) _directive: std::marker::PhantomData<T>,
+    pub(crate) exclude_checkers: Arc<[Box<dyn NodeChecker>]>,
+    pub(crate) remove_checkers: Arc<[Box<dyn NodeChecker>]>,
+    pub(crate) attr_exclude_checkers: Arc<[Box<dyn AttrChecker>]>,
+    pub(crate) _directive: std::marker::PhantomData<T>,
 }
 
 impl<T: SanitizeDirective> fmt::Debug for PluginPolicy<T> {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -3,8 +3,11 @@ pub mod core;
 pub mod ext;
 pub mod preset;
 
+#[doc(inline)]
 pub use builder::PolicyBuilder;
+#[doc(inline)]
 pub use ext::SanitizeExt;
-
+#[doc(inline)]
 pub use core::{AllowAllPolicy, DenyAllPolicy, PermissivePolicy, RestrictivePolicy};
-pub use core::{AttributeRule, Policy};
+#[doc(inline)]
+pub use core::Policy;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -6,8 +6,8 @@ pub mod preset;
 #[doc(inline)]
 pub use builder::PolicyBuilder;
 #[doc(inline)]
-pub use ext::SanitizeExt;
+pub use core::Policy;
 #[doc(inline)]
 pub use core::{AllowAllPolicy, DenyAllPolicy, PermissivePolicy, RestrictivePolicy};
 #[doc(inline)]
-pub use core::Policy;
+pub use ext::SanitizeExt;

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -13,12 +13,12 @@ fn is_node_name_in(names: &[LocalName], node: &NodeRef) -> bool {
 
 /// An **excluding** rule for sanitizing attributes of a specific element.
 #[derive(Debug, Clone, Default)]
-pub struct AttributeRule<'a> {
+pub (crate) struct AttributeRule<'a> {
     /// The name of the element to which this rule applies.
     /// If `None`, the rule applies to all elements.
-    pub element: Option<LocalName>,
+    pub (crate) element: Option<LocalName>,
     /// The list of attribute keys to be excluded.
-    pub attributes: &'a [&'a str],
+    pub (crate) attributes: &'a [&'a str],
 }
 
 #[derive(Debug, Clone)]
@@ -26,25 +26,14 @@ pub struct Policy<'a, T: SanitizeDirective = Restrictive> {
     /// The list of excluding rules for attributes.
     /// For [Permissive] directive: attributes to remove
     /// For [Restrictive] directive: attributes to keep
-    pub attrs_to_exclude: Vec<AttributeRule<'a>>,
+    pub (crate) attrs_to_exclude: Vec<AttributeRule<'a>>,
     /// The list of element names excluded from the base [Policy].
     /// For [Permissive] directive: elements to remove (keeping their children)
     /// For [Restrictive] directive: elements to keep
-    pub elements_to_exclude: Vec<LocalName>,
+    pub (crate) elements_to_exclude: Vec<LocalName>,
     /// Specifies the names of elements to remove from the DOM with their children during sanitization.
-    pub elements_to_remove: Vec<LocalName>,
-    pub(crate) _directive: std::marker::PhantomData<T>,
-}
-
-impl<T: SanitizeDirective> Default for Policy<'_, T> {
-    fn default() -> Self {
-        Self {
-            attrs_to_exclude: Vec::new(),
-            elements_to_exclude: Vec::new(),
-            elements_to_remove: Vec::new(),
-            _directive: std::marker::PhantomData,
-        }
-    }
+    pub (crate) elements_to_remove: Vec<LocalName>,
+    pub (crate) _directive: std::marker::PhantomData<T>,
 }
 
 impl<T: SanitizeDirective> Policy<'_, T> {
@@ -118,7 +107,7 @@ impl<'a, T: SanitizeDirective> Policy<'a, T> {
 
     /// Creates a new [`Policy`] with default values.
     pub fn new() -> Self {
-        Self::default()
+        Self::builder().build()
     }
 }
 

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -13,12 +13,12 @@ fn is_node_name_in(names: &[LocalName], node: &NodeRef) -> bool {
 
 /// An **excluding** rule for sanitizing attributes of a specific element.
 #[derive(Debug, Clone, Default)]
-pub (crate) struct AttributeRule<'a> {
+pub(crate) struct AttributeRule<'a> {
     /// The name of the element to which this rule applies.
     /// If `None`, the rule applies to all elements.
-    pub (crate) element: Option<LocalName>,
+    pub(crate) element: Option<LocalName>,
     /// The list of attribute keys to be excluded.
-    pub (crate) attributes: &'a [&'a str],
+    pub(crate) attributes: &'a [&'a str],
 }
 
 #[derive(Debug, Clone)]
@@ -26,14 +26,14 @@ pub struct Policy<'a, T: SanitizeDirective = Restrictive> {
     /// The list of excluding rules for attributes.
     /// For [Permissive] directive: attributes to remove
     /// For [Restrictive] directive: attributes to keep
-    pub (crate) attrs_to_exclude: Vec<AttributeRule<'a>>,
+    pub(crate) attrs_to_exclude: Vec<AttributeRule<'a>>,
     /// The list of element names excluded from the base [Policy].
     /// For [Permissive] directive: elements to remove (keeping their children)
     /// For [Restrictive] directive: elements to keep
-    pub (crate) elements_to_exclude: Vec<LocalName>,
+    pub(crate) elements_to_exclude: Vec<LocalName>,
     /// Specifies the names of elements to remove from the DOM with their children during sanitization.
-    pub (crate) elements_to_remove: Vec<LocalName>,
-    pub (crate) _directive: std::marker::PhantomData<T>,
+    pub(crate) elements_to_remove: Vec<LocalName>,
+    pub(crate) _directive: std::marker::PhantomData<T>,
 }
 
 impl<T: SanitizeDirective> Policy<'_, T> {
@@ -103,11 +103,6 @@ impl<'a, T: SanitizeDirective> Policy<'a, T> {
     /// Creates a new [`PolicyBuilder`] with default values.
     pub fn builder() -> PolicyBuilder<'a, T> {
         PolicyBuilder::new()
-    }
-
-    /// Creates a new [`Policy`] with default values.
-    pub fn new() -> Self {
-        Self::builder().build()
     }
 }
 

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -64,7 +64,7 @@ fn test_permissive_policy_attrs() {
 
 #[test]
 fn test_restrictive_policy_simple() {
-    let policy = DenyAllPolicy::new();
+    let policy = DenyAllPolicy::builder().build();
     let doc = Document::from(PARAGRAPH_CONTENTS);
     doc.root().sanitize(&policy);
     assert!(!doc.select("div").exists());
@@ -84,7 +84,7 @@ fn test_restrictive_policy_simple() {
 
 #[test]
 fn test_permissive_policy_simple() {
-    let policy = AllowAllPolicy::new();
+    let policy = AllowAllPolicy::builder().build();
     let doc = Document::from(PARAGRAPH_CONTENTS);
     doc.sanitize(&policy);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved documentation visibility for several re-exported items by inlining their documentation into module-level docs.
- **Refactor**
  - Restricted visibility of certain struct fields and types to within the crate, enhancing encapsulation.
  - Removed a previously public re-export and an explicit default implementation for a struct.
  - Updated a constructor to use a builder pattern for instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->