### PR TITLE
implement `sanitize_selection` for `Policy` and `PluginPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- Implemented the `Policy::sanitize_selection` and `PluginPolicy::sanitize_selection` methods to sanitize only nodes within the selected set of nodes.
+
 ### Fixed
 - Fixed incorrect node retrieval in `next_child_or_sibling`, except for the root node.

--- a/Examples.md
+++ b/Examples.md
@@ -243,6 +243,47 @@ for handle in handles {
 </details>
 
 
+<details> 
+<summary><b>Sanitizing Only Nodes Inside a Selection</b></summary>
+
+`dom_sanitizer` allows you to apply sanitization only to nodes within a selected set of nodes. 
+This is useful when you want to sanitize specific parts of a document without affecting the rest of it.
+
+```rust
+use dom_sanitizer::RestrictivePolicy;
+use dom_query::Document;
+
+let contents: &str = r#"
+    <!DOCTYPE html>
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <style>
+                p { border-bottom: 2px solid black; }
+            </style>
+            <div><p role="paragraph">The first paragraph contains <a href="/first" role="link">the first link</a>.</p></div>
+            <div><p role="paragraph">The second paragraph contains <a href="/second" role="link">the second link</a>.</p></div>
+            <div><p role="paragraph">The third paragraph contains <a href="/third" role="link">the third link</a>.</p></div>
+            <div><p id="highlight" role="paragraph"><mark>highlighted text</mark>, <b>bold text</b></p></div>
+            <div></div>
+        </body>
+    </html>"#;
+let policy = RestrictivePolicy::builder().build();
+let doc = Document::from(contents);
+
+// Before sanitization, there are no paragraphs that contain only text content
+assert!(!doc.select("p:only-text").exists());
+
+let sel = doc.select("p");
+policy.sanitize_selection(&sel);
+
+// After sanitization, all paragraphs contain only text content
+assert_eq!(doc.select("p:only-text").length(), 4);
+
+```
+</details>
+
+
 ---
 When the basic `Policy` capabilities are not enough, `PluginPolicy` allows
 you to define a fully customized sanitization policy.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,45 @@ for handle in handles {
 ```
 </details>
 
+<details> 
+<summary><b>Sanitizing Only Nodes Inside a Selection</b></summary>
+
+`dom_sanitizer` allows you to apply sanitization only to nodes within a selected set of nodes. 
+This is useful when you want to sanitize specific parts of a document without affecting the rest of it.
+
+```rust
+use dom_sanitizer::RestrictivePolicy;
+use dom_query::Document;
+
+let contents: &str = r#"
+    <!DOCTYPE html>
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <style>
+                p { border-bottom: 2px solid black; }
+            </style>
+            <div><p role="paragraph">The first paragraph contains <a href="/first" role="link">the first link</a>.</p></div>
+            <div><p role="paragraph">The second paragraph contains <a href="/second" role="link">the second link</a>.</p></div>
+            <div><p role="paragraph">The third paragraph contains <a href="/third" role="link">the third link</a>.</p></div>
+            <div><p id="highlight" role="paragraph"><mark>highlighted text</mark>, <b>bold text</b></p></div>
+            <div></div>
+        </body>
+    </html>"#;
+let policy = RestrictivePolicy::builder().build();
+let doc = Document::from(contents);
+
+// Before sanitization, there are no paragraphs that contain only text content
+assert!(!doc.select("p:only-text").exists());
+
+let sel = doc.select("p");
+policy.sanitize_selection(&sel);
+
+// After sanitization, all paragraphs contain only text content
+assert_eq!(doc.select("p:only-text").length(), 4);
+
+```
+</details>
 
 ---
 When the basic `Policy` capabilities are not enough, `PluginPolicy` allows

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod plugin_policy;
 pub mod policy;
 pub mod traits;
 
+pub(crate) mod macros;
+
 #[doc(inline)]
 pub use directives::{Permissive, Restrictive};
 pub use policy::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! sanitize_methods {
 
         /// Sanitizes the HTML content by applying the policy rules according to the directive type.
         pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
-            let doc = Document::from(html);
+            let doc = dom_query::Document::from(html);
             self.sanitize_document(&doc);
             doc.html()
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,33 @@
+macro_rules! sanitize_methods {
+    () => {
+        /// Sanitizes a node by applying the policy rules according to the directive type.
+        ///
+        /// For [Permissive] directive: Removes elements and attributes specified in the policy.
+        /// For [Restrictive] directive: Keeps only elements and attributes specified in the policy.
+        pub fn sanitize_node(&self, node: &dom_query::NodeRef) {
+            T::sanitize_node(self, node);
+            node.normalize();
+        }
+
+        /// Sanitizes the [dom_query::Document].
+        pub fn sanitize_document(&self, document: &dom_query::Document) {
+            self.sanitize_node(&document.root());
+        }
+
+        /// Sanitizes the [dom_query::Selection].
+        pub fn sanitize_selection(&self, sel: &dom_query::Selection) {
+            for node in sel.nodes() {
+                self.sanitize_node(node);
+            }
+        }
+
+        /// Sanitizes the HTML content by applying the policy rules according to the directive type.
+        pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
+            let doc = Document::from(html);
+            self.sanitize_document(&doc);
+            doc.html()
+        }
+    };
+}
+
+pub(crate) use sanitize_methods;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,6 @@
 macro_rules! sanitize_methods {
+    // This macro generates sanitization methods for a type implementing a sanitization trait T.
+    // T must provide a `sanitize_node` method that the generated methods will delegate to.
     () => {
         /// Sanitizes a node by applying the policy rules according to the directive type.
         ///

--- a/src/plugin_policy/core.rs
+++ b/src/plugin_policy/core.rs
@@ -6,6 +6,7 @@ use html5ever::Attribute;
 use tendril::StrTendril;
 
 use super::builder::PluginPolicyBuilder;
+use crate::macros::sanitize_methods;
 use crate::traits::{SanitizeDirective, SanitizePolicy};
 use crate::{Permissive, Restrictive};
 
@@ -110,27 +111,10 @@ impl<T: SanitizeDirective> PluginPolicy<T> {
         }
         false
     }
+}
 
-    /// Sanitizes a node by applying the policy rules according to the directive type.
-    ///
-    /// For [Permissive] directive: Removes elements and attributes specified in the policy.
-    /// For [Restrictive] directive: Keeps only elements and attributes specified in the policy.
-    pub fn sanitize_node(&self, node: &NodeRef) {
-        T::sanitize_node(self, node);
-        node.normalize();
-    }
-
-    /// Sanitizes the document.
-    pub fn sanitize_document(&self, document: &Document) {
-        self.sanitize_node(&document.root());
-    }
-
-    /// Sanitizes the HTML content by applying the policy rules according to the directive type.
-    pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
-        let doc = Document::from(html);
-        self.sanitize_document(&doc);
-        doc.html()
-    }
+impl<T: SanitizeDirective> PluginPolicy<T> {
+    sanitize_methods!();
 }
 
 impl<T: SanitizeDirective> PluginPolicy<T> {

--- a/src/plugin_policy/core.rs
+++ b/src/plugin_policy/core.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use dom_query::{Document, NodeRef};
+use dom_query::NodeRef;
 use html5ever::Attribute;
 use tendril::StrTendril;
 

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -3,6 +3,7 @@ use html5ever::LocalName;
 use tendril::StrTendril;
 
 use super::builder::PolicyBuilder;
+use crate::macros::sanitize_methods;
 use crate::traits::{SanitizeDirective, SanitizePolicy};
 use crate::{Permissive, Restrictive};
 
@@ -37,24 +38,7 @@ pub struct Policy<'a, T: SanitizeDirective = Restrictive> {
 }
 
 impl<T: SanitizeDirective> Policy<'_, T> {
-    /// Sanitizes a node by applying the policy rules according to the directive type.
-    ///
-    /// For [Permissive] directive: Removes elements and attributes specified in the policy.
-    /// For [Restrictive] directive: Keeps only elements and attributes specified in the policy.
-    pub fn sanitize_node(&self, node: &dom_query::NodeRef) {
-        T::sanitize_node(self, node);
-        node.normalize();
-    }
-    /// Sanitizes the document.
-    pub fn sanitize_document(&self, document: &Document) {
-        self.sanitize_node(&document.root());
-    }
-    /// Sanitizes the HTML content by applying the policy rules according to the directive type.
-    pub fn sanitize_html<S: Into<StrTendril>>(&self, html: S) -> StrTendril {
-        let doc = Document::from(html);
-        self.sanitize_document(&doc);
-        doc.html()
-    }
+    sanitize_methods!();
 }
 
 impl<T: SanitizeDirective> SanitizePolicy for Policy<'_, T> {

--- a/src/policy/core.rs
+++ b/src/policy/core.rs
@@ -1,4 +1,4 @@
-use dom_query::{Document, NodeRef};
+use dom_query::NodeRef;
 use html5ever::LocalName;
 use tendril::StrTendril;
 

--- a/src/policy/ext.rs
+++ b/src/policy/ext.rs
@@ -21,3 +21,10 @@ impl SanitizeExt for Document {
         policy.sanitize_document(self);
     }
 }
+
+impl SanitizeExt for dom_query::Selection<'_> {
+    /// Sanitizes all nodes in the selection using the provided policy.
+    fn sanitize<T: SanitizeDirective>(&self, policy: &Policy<T>) {
+        policy.sanitize_selection(self);
+    }
+}

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -162,7 +162,5 @@ fn test_restrictive_selection() {
     assert!(!doc.select("p:only-text").exists());
 
     sel.sanitize(&policy);
-    //policy.sanitize_selection(&doc.select("p"));
-
     assert_eq!(doc.select("p:only-text").length(), 4);
 }

--- a/tests/policy.rs
+++ b/tests/policy.rs
@@ -153,3 +153,16 @@ fn test_restrictive_policy_remove_html() {
     assert!(!html.contains("<style>"));
     assert!(!html.contains("border-collapse: collapse"));
 }
+
+#[test]
+fn test_restrictive_selection() {
+    let policy = DenyAllPolicy::builder().build();
+    let doc = Document::from(PARAGRAPH_CONTENTS);
+    let sel = doc.select("p");
+    assert!(!doc.select("p:only-text").exists());
+
+    sel.sanitize(&policy);
+    //policy.sanitize_selection(&doc.select("p"));
+
+    assert_eq!(doc.select("p:only-text").length(), 4);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added examples and documentation demonstrating how to sanitize only selected nodes within a document.
  - Updated the changelog to reflect new selective sanitization methods.
- **New Features**
  - Introduced the ability to sanitize only nodes inside a selection, allowing more targeted sanitization.
- **Tests**
  - Added a test to verify selective sanitization of node selections.
- **Refactor**
  - Streamlined sanitization method implementations using a macro for consistency and maintainability.
- **Chores**
  - Added internal macros to reduce code duplication.
  - Extended sanitization trait support to selections for unified API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->